### PR TITLE
fix: segfault when pcre2_compile_8 fails

### DIFF
--- a/pcre.c
+++ b/pcre.c
@@ -73,7 +73,9 @@ void regexp(sqlite3_context *ctx, int argc, sqlite3_value **argv)
             size_t pos;
             c.p = pcre2_compile_8(re, PCRE2_ZERO_TERMINATED, 0, &err, &pos, NULL);
             if (!c.p) {
-                char *e2 = sqlite3_mprintf("%s: %s (offset %d)", re, err, pos);
+                PCRE2_UCHAR errbuf[256];
+                pcre2_get_error_message_8(err, errbuf, sizeof(errbuf));
+                char *e2 = sqlite3_mprintf("%s: %s (offset %d)", re, (char *) errbuf, (int) pos);
                 sqlite3_result_error(ctx, e2, -1);
                 sqlite3_free(e2);
                 return;


### PR DESCRIPTION
Hit this while using gufi_query and any bad regex would just crash the whole process. Tracked it down to this extension.
#### Repro

  ```sh
  sqlite3 <<'EOF'
  .load ./libsqlite3-pcre.so sqlite3_pcre2_init
  SELECT 'x' REGEXP '^*';
  EOF

  Crashes with SIGSEGV. Same thing for [abc, *foo, or any pattern
  that fails to compile.

  Stack trace:
  #0  __strlen_asimd
  #1  sqlite3_str_vappendf
  #2  sqlite3_mprintf
  #3  regexp           at pcre.c:76
  ```
  
Tested in the sqlite3 shell:
```
  - 'x' REGEXP '^*' → Runtime error: ^*: quantifier does not follow a repeatable item (offset 1)
  - 'x' REGEXP '[abc' → Runtime error: [abc: missing terminating ] for character class (offset 4)
  - 'hello.txt' REGEXP '\.txt$' → 1
  - 'hello.doc' REGEXP '\.txt$' → 0
  ```